### PR TITLE
Fixed typo issue #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Run the following command to install the required dependencies.
 6. Stage your changes and commit
 
 ```yml
-git add -a
+git add .
 
 git commit -m "<your_commit_message>"
 ```


### PR DESCRIPTION
Fixes #55

#### Short description of what this resolves:

Typo error in README.md #55

#### What Changes proposed in this pull request:
- Changed "git add -a" to "git add ."

#### Checklist

- [x] Added description of change
- [x] Relevant documentation/comments is changed or added
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: 
Fixed typo error in README.md
